### PR TITLE
limit s3 object list by year and month preset

### DIFF
--- a/getPhotos/main.go
+++ b/getPhotos/main.go
@@ -8,10 +8,12 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"sort"
 	"strconv"
+	"time"
 )
 
 func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	objects, err := s3.ListObjectsInBucket("backyard-photos")
+	now := time.Now()
+	objects, err := s3.ListObjectsInBucket("backyard-photos", fmt.Sprintf("%d-%d", now.Year(), now.Month() ))
 
 	if err != nil {
 		fmt.Println(err)

--- a/getPhotos/s3/main.go
+++ b/getPhotos/s3/main.go
@@ -58,10 +58,10 @@ func upload(body io.ReadSeeker, bucket, key, region string, timeout time.Duratio
 	fmt.Printf("successfully uploaded file to %s/%s\n", bucket, key)
 }
 
-func ListObjectsInBucket(bucket string) (*s3.ListObjectsV2Output, error) {
+func ListObjectsInBucket(bucket string, prefix string) (*s3.ListObjectsV2Output, error) {
 	client := getS3Client("ap-southeast-2")
 
-	res, err := client.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: &bucket})
+	res, err := client.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: &bucket, Prefix: aws.String(prefix)})
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`ListObjectInBucket` only fetches the first 1000 objects, this PR filters the objects returned to those that fit the prefix `year-month` (e.g. `2021-12`)